### PR TITLE
Fix import error in documentation build. 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 # serve to show the default.
 from __future__ import unicode_literals
 
-import django
 import os
 import sys
 
@@ -25,6 +24,7 @@ project_root = os.path.dirname(cwd)
 # version is used.
 sys.path.insert(0, project_root)
 
+import django
 from django.conf import settings  # noqa
 settings.configure()
 django.setup()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 # serve to show the default.
 from __future__ import unicode_literals
 
+import django
 import os
 import sys
 
@@ -26,6 +27,7 @@ sys.path.insert(0, project_root)
 
 from django.conf import settings  # noqa
 settings.configure()
+django.setup()
 
 import gargoyle  # noqa
 


### PR DESCRIPTION
In particular this impacts the ConditionSet API documentation.

This will cause documentation builds on older Django versions to fail (<1.9 I think).